### PR TITLE
Fix FAQ link to use lowercase 'faqs' directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ November 19, 2024 is a milestone in the continued progress of the OCSF consortiu
 
 ## FAQ
 
-We are maintaining a list of [FAQs here](https://github.com/ocsf/ocsf-docs/tree/main/FAQs).
+We are maintaining a list of [FAQs here](https://github.com/ocsf/ocsf-docs/tree/main/faqs).
 
 ## Contributors
 


### PR DESCRIPTION
- Updated FAQ link from /FAQs to /faqs to match the correct directory structure
- Ensures users can properly access the FAQ documentation